### PR TITLE
Add #if MONO to integrate corert parts into Mono

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -11,6 +11,9 @@
 **
 ===========================================================*/
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.ExceptionServices;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
@@ -4,6 +4,9 @@
 
 using Microsoft.Win32.SafeHandles;
 using System;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
@@ -4,6 +4,9 @@
 
 using Microsoft.Win32.SafeHandles;
 using System;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -4,6 +4,9 @@
 
 using Microsoft.Win32.SafeHandles;
 using System;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -130,6 +130,7 @@ internal partial class Interop
     }
 }
 
+#if !MONO
 namespace System.Runtime.InteropServices
 {
     internal class Marshal
@@ -177,3 +178,4 @@ namespace System.Runtime.InteropServices
 #endif
     }
 }
+#endif

--- a/src/System.Private.CoreLib/src/System/Collections/Concurrent/LowLevelConcurrentQueue.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Concurrent/LowLevelConcurrentQueue.cs
@@ -16,6 +16,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -12,6 +12,9 @@
 ===========================================================*/
 
 using System.Runtime;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -8,7 +8,10 @@ using System.Threading;
 
 namespace System
 {
-    internal static partial class Environment
+#if !MONO 
+    internal 
+#endif
+    static partial class Environment
     {
         internal static int CurrentNativeThreadId => ManagedThreadId.Current;
 
@@ -20,7 +23,9 @@ namespace System
             }
         }
 
+#if !MONO
         public static int ProcessorCount => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
+#endif
 
         private static int ComputeExecutionId()
         {

--- a/src/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -4,12 +4,16 @@
 
 namespace System
 {
-    internal static partial class Environment
+#if !MONO
+    internal 
+#endif
+    static partial class Environment
     {
         internal static int CurrentNativeThreadId => unchecked((int)Interop.mincore.GetCurrentThreadId());
 
         internal static long TickCount64 => (long)Interop.mincore.GetTickCount64();
 
+#if !MONO
         public static int ProcessorCount
         {
             get
@@ -20,7 +24,7 @@ namespace System
                 return (int)info.dwNumberOfProcessors;
             }
         }
-
+#endif
         private static int ComputeExecutionId() => (int)Interop.mincore.GetCurrentProcessorNumber();
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
@@ -14,8 +14,12 @@
 ** 
 ===========================================================*/
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System;
 using System.Threading;
+using System.Diagnostics;
 using System.Runtime.ConstrainedExecution;
 
 namespace System.Runtime.InteropServices
@@ -118,13 +122,16 @@ namespace System.Runtime.InteropServices
       1) Requires some magic to run the critical finalizer.
     */
 
-    public abstract class SafeHandle : CriticalFinalizerObject, IDisposable
+    public abstract partial class SafeHandle : CriticalFinalizerObject, IDisposable
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2111:PointersShouldNotBeVisible")]
         protected IntPtr handle;        // PUBLICLY DOCUMENTED handle field
 
         private int _state;            // Combined ref count and closed/disposed flags (so we can atomically modify them).
         private bool _ownsHandle;       // Whether we can release this handle.
+#if MONO
+        private bool _fullyInitialized;  // Whether constructor completed.
+#endif
 
         // Bitmasks for the _state field above.
         private static class StateBits
@@ -146,6 +153,14 @@ namespace System.Runtime.InteropServices
 
             if (!ownsHandle)
                 GC.SuppressFinalize(this);
+
+#if MONO
+            // Set this last to prevent SafeHandle's finalizer from freeing an
+            // invalid handle.  This means we don't have to worry about 
+            // ThreadAbortExceptions interrupting this constructor or the managed
+            // constructors on subclasses that call this constructor.
+           _fullyInitialized = true;
+#endif
         }
 
         //
@@ -202,7 +217,7 @@ namespace System.Runtime.InteropServices
         internal void InitializeHandle(IntPtr _handle)
         {
             // The SafeHandle should be invalid to be able to initialize it
-            System.Diagnostics.Debug.Assert(IsInvalid);
+            Debug.Assert(IsInvalid);
 
             handle = _handle;
         }
@@ -252,6 +267,7 @@ namespace System.Runtime.InteropServices
             GC.SuppressFinalize(this);
         }
 
+#if !MONO
         public void SetHandleAsInvalid()
         {
             int oldState, newState;
@@ -265,7 +281,7 @@ namespace System.Runtime.InteropServices
                 newState = oldState | StateBits.Closed;
             } while (Interlocked.CompareExchange(ref _state, newState, oldState) != oldState);
         }
-
+#endif
         // Implement this abstract method in your derived class to specify how to
         // free the handle. Be careful not write any code that's subject to faults
         // in this method (the runtime will prepare the infrastructure for you so
@@ -276,6 +292,7 @@ namespace System.Runtime.InteropServices
         // MDA is enabled.
         protected abstract bool ReleaseHandle();
 
+#if !MONO
         // Add a reason why this handle should not be relinquished (i.e. have
         // ReleaseHandle called on it). This method has dangerous in the name since
         // it must always be used carefully (e.g. called within a CER) to avoid
@@ -308,7 +325,7 @@ namespace System.Runtime.InteropServices
         {
             InternalRelease(false);
         }
-
+#endif
         // Do not call this directly - only call through the extension method SafeHandleExtensions.DangerousAddRef.
         internal void DangerousAddRef_WithNoNullCheck()
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -267,7 +270,7 @@ namespace System.Runtime
         //
         // calls to runtime for type equality checks
         //
-
+#if !MONO
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_AreTypesEquivalent")]
         internal static extern bool AreTypesEquivalent(EETypePtr pType1, EETypePtr pType2);
@@ -275,11 +278,13 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_AreTypesAssignable")]
         internal static extern bool AreTypesAssignable(EETypePtr pSourceType, EETypePtr pTargetType);
+#endif
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_CheckArrayStore")]
         internal static extern void RhCheckArrayStore(Object array, Object obj);
 
+#if !MONO
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOf")]
         internal static extern object IsInstanceOf(object obj, EETypePtr pTargetType);
@@ -330,6 +335,7 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhUnbox")]
         internal static extern unsafe void RhUnbox(object obj, ref byte data, EETypePtr pUnboxToEEType);
+#endif
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhMemberwiseClone")]
@@ -363,10 +369,10 @@ namespace System.Runtime
             return RhCompatibleReentrantWaitAny(alertable ? 1 : 0, timeout, count, handles);
         }
 
+#if !MONO
         //
         // EEType interrogation methods.
         //
-
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetGCDescSize")]
         internal static extern int RhGetGCDescSize(EETypePtr eeType);
@@ -383,6 +389,7 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhResolveDispatch")]
         internal static extern IntPtr RhResolveDispatch(object pObject, EETypePtr pInterfaceType, ushort slot);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpResolveInterfaceMethod")]
@@ -416,9 +423,11 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetThreadLocalStorageForDynamicType")]
         internal static extern IntPtr RhGetThreadLocalStorageForDynamicType(int index, int tlsStorageSize, int numTlsCells);
 
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhResolveDispatchOnType")]
         internal static extern IntPtr RhResolveDispatchOnType(EETypePtr instanceType, EETypePtr interfaceType, ushort slot);
+#endif
 
         // Keep in sync with RH\src\rtu\runtimeinstance.cpp
         internal enum RuntimeHelperKind
@@ -430,6 +439,7 @@ namespace System.Runtime
             CheckArrayElementType,
         }
 
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetRuntimeHelperForType")]
         internal static extern unsafe IntPtr RhGetRuntimeHelperForType(EETypePtr pEEType, RuntimeHelperKind kind);
@@ -437,6 +447,7 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetDispatchMapForType")]
         internal static extern unsafe IntPtr RhGetDispatchMapForType(EETypePtr pEEType);
+#endif
 
         //
         // Support for GC and HandleTable callouts.
@@ -458,6 +469,7 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhUnregisterGcCallout")]
         internal static extern void RhUnregisterGcCallout(GcRestrictedCalloutKind eKind, IntPtr pCalloutMethod);
 
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhRegisterRefCountedHandleCallback")]
         internal static extern bool RhRegisterRefCountedHandleCallback(IntPtr pCalloutMethod, EETypePtr pTypeFilter);
@@ -465,11 +477,13 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhUnregisterRefCountedHandleCallback")]
         internal static extern void RhUnregisterRefCountedHandleCallback(IntPtr pCalloutMethod, EETypePtr pTypeFilter);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhIsPromoted")]
         internal static extern bool RhIsPromoted(object obj);
 
+#if !MONO
         //
         // Blob support
         //
@@ -485,11 +499,13 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpCreateTypeManager")]
         internal static extern unsafe TypeManagerHandle RhpCreateTypeManager(IntPtr osModule, IntPtr moduleHeader, IntPtr* pClasslibFunctions, int nClasslibFunctions);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpRegisterOsModule")]
         internal static extern unsafe IntPtr RhpRegisterOsModule(IntPtr osModule);
 
+#if !MONO
         [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern IntPtr RhGetModuleSection(ref TypeManagerHandle module, ReadyToRunSectionType section, out int length);
@@ -498,6 +514,7 @@ namespace System.Runtime
         {
             return RhGetModuleSection(ref module, section, out length);
         }
+#endif
 
 #if CORERT
         internal static uint RhGetLoadedOSModules(IntPtr[] resultArray)
@@ -523,19 +540,22 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetLoadedOSModules")]
         internal static extern uint RhGetLoadedOSModules(IntPtr[] resultArray);
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetLoadedModules")]
         internal static extern uint RhGetLoadedModules(TypeManagerHandle[] resultArray);
+#endif
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetOSModuleFromPointer")]
         internal static extern IntPtr RhGetOSModuleFromPointer(IntPtr pointerVal);
 
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetModuleFromEEType")]
         internal static extern TypeManagerHandle RhGetModuleFromEEType(IntPtr pEEType);
-
+#endif
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetOSModuleFromEEType")]
         internal static extern IntPtr RhGetOSModuleFromEEType(IntPtr pEEType);
@@ -544,9 +564,11 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetOSModuleForMrt")]
         internal static extern IntPtr RhGetOSModuleForMrt();
 
+#if !MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticFieldAddress")]
         internal static extern unsafe byte* RhGetThreadStaticFieldAddress(EETypePtr pEEType, IntPtr fieldCookie);
+#endif
 
 #if CORERT
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -614,7 +636,7 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetCurrentThreadStackBounds")]
         internal static extern void RhGetCurrentThreadStackBounds(out IntPtr pStackLow, out IntPtr pStackHigh);
 
-#if PLATFORM_UNIX
+#if PLATFORM_UNIX || MONO
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhSetThreadExitCallback")]
         internal static extern bool RhSetThreadExitCallback(IntPtr pCallback);

--- a/src/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -5,6 +5,9 @@
 #pragma warning disable 0420 //passing volatile fields by ref
 
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
@@ -18,6 +18,9 @@ using System.Runtime.InteropServices;
 using System.Diagnostics.Contracts;
 using Microsoft.Win32.SafeHandles;
 using System.IO;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using Internal.Runtime.Augments;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Internal.Runtime.Augments;

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using Internal.Runtime.Augments;
 

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using Internal.Runtime.Augments;
 

--- a/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
@@ -9,6 +9,9 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using Internal.Runtime.Augments;
 using System.Diagnostics;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.IO;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#else
 using System.Diagnostics;
+#endif
 using System.IO;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#else
 using System.Diagnostics;
+#endif
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 

--- a/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -12,6 +12,9 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/ConcurrentExclusiveSchedulerPair.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/ConcurrentExclusiveSchedulerPair.cs
@@ -16,6 +16,9 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -12,6 +12,9 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Runtime.CompilerServices;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
@@ -11,6 +11,9 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
@@ -25,6 +25,9 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -13,6 +13,9 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -11,6 +11,9 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskExceptionHolder.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskExceptionHolder.cs
@@ -17,6 +17,9 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskFactory.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskFactory.cs
@@ -14,6 +14,9 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -15,6 +15,9 @@
 
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -28,6 +28,9 @@
 
 using Internal.Runtime.Augments;
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.IO;
 using System.Runtime;

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -11,6 +11,9 @@
 **
 =============================================================================*/
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
@@ -30,6 +33,10 @@ namespace System.Threading
         protected static readonly IntPtr InvalidHandle = Interop.InvalidHandleValue;
 
         internal SafeWaitHandle _waitHandle;
+
+#pragma warning disable 414  // Field is not used from managed.
+        private IntPtr waitHandle;  // !!! DO NOT MOVE THIS FIELD. (See defn of WAITHANDLEREF in object.h - has hardcoded access to this field.)
+#pragma warning restore 414
 
         internal enum OpenExistingResult
         {
@@ -86,6 +93,12 @@ namespace System.Threading
 
             set
             { _waitHandle = value; }
+        }
+
+        internal void SetHandleInternal(SafeWaitHandle handle)
+        {
+            SafeWaitHandle = handle;
+            waitHandle = handle.DangerousGetHandle();
         }
 
         internal static int ToTimeoutMilliseconds(TimeSpan timeout)

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandleArray.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandleArray.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using Internal.Runtime.Augments;
 

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Internal.Runtime.Augments;

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO
+using System.Diagnostics.Private;
+#endif
 using System.Diagnostics;
 using Internal.Runtime.Augments;
 


### PR DESCRIPTION
As part of integration synchronization primitives from corert into Mono additional #if MONO were added. It was made to add Mono's specific namespaces as well to define method's names to allow integration with mono codebase.

/CC @marek-safar 