### PR TITLE
Hide Task.ExecuteWithThreadLocal() on mono

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -127,7 +127,7 @@ namespace System.Threading.Tasks
     /// </remarks>
     [DebuggerTypeProxy(typeof(SystemThreadingTasks_TaskDebugView))]
     [DebuggerDisplay("Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription}")]
-    public class Task : IThreadPoolWorkItem, IAsyncResult, IDisposable
+    public partial class Task : IThreadPoolWorkItem, IAsyncResult, IDisposable
     {
         internal static int s_taskIdCounter; //static counter used to generate unique task IDs
 
@@ -2420,6 +2420,7 @@ namespace System.Threading.Tasks
             return true;
         }
 
+#if !MONO
         // A trick so we can refer to the TLS slot with a byref.
         private void ExecuteWithThreadLocal(ref Task currentTaskSlot)
         {
@@ -2474,6 +2475,7 @@ namespace System.Threading.Tasks
                     TaskTrace.TaskCompleted(TaskScheduler.Current.Id, 0, this.Id, IsFaulted);
             }
         }
+#endif
 
         // Cached callback delegate that's lazily initialized due to ContextCallback being SecurityCritical
         private static ContextCallback s_ecCallback;


### PR DESCRIPTION
Since we still use _old_ version of ExecutionContext, ThreadPool, Thread and SynchronizationContext - I have to bring back the old implementation for this method on mono.
Needed for https://github.com/mono/mono/pull/6672