### PR TITLE
[wasm] Ignore TaskCreationOptions.LongRunning under WebAssembly as multiple-threads are not supported.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -48,7 +48,7 @@ namespace System.Threading.Tasks
                                                  task.Id, creatingTask == null ? 0 : creatingTask.Id,
                                                  (int)task.Options);
             }
-
+#if !WASM
             if ((task.Options & TaskCreationOptions.LongRunning) != 0)
             {
                 // Run LongRunning tasks on their own dedicated thread.
@@ -57,6 +57,8 @@ namespace System.Threading.Tasks
                 thread.Start(task);
             }
             else
+#endif
+
             {
                 // Normal handling for non-LongRunning tasks.
                 bool forceToGlobalQueue = ((task.Options & TaskCreationOptions.PreferFairness) != 0);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7864