### PR TITLE
Hide typeforwarders for mono

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -7,9 +7,6 @@ using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-#if MONO
-using System.Diagnostics.Private;
-#endif
 
 namespace System.Collections.Generic
 {

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Diagnostics.Private;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -4,7 +4,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics.Private;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/shared/System/Tuple.cs
+++ b/src/System.Private.CoreLib/shared/System/Tuple.cs
@@ -4,9 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
-#if MONO
-using System.Diagnostics.Private;
-#endif
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 

--- a/src/System.Private.CoreLib/shared/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/shared/System/ValueTuple.cs
@@ -8,9 +8,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using HashHelpers = System.Numerics.Hashing.HashHelpers;
-#if MONO
-using System.Diagnostics.Private;
-#endif
 
 namespace System
 {

--- a/src/System.Private.CoreLib/src/System/Marvin.cs
+++ b/src/System.Private.CoreLib/src/System/Marvin.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Private;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 using Internal.Runtime.CompilerServices;

--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Private;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -10,7 +10,6 @@
 
 
 using System.Diagnostics;
-using System.Diagnostics.Private;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 

--- a/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -9,7 +9,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Private;
 using System.Runtime.InteropServices;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadInterruptedException.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadInterruptedException.cs
@@ -17,7 +17,9 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class ThreadInterruptedException : SystemException
     {
         public ThreadInterruptedException()

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -17,7 +17,6 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Diagnostics;
-using System.Diagnostics.Private;
 using System.Collections.Generic;
 
 namespace System.Threading

--- a/src/System.Private.Interop/src/Shared/ComException.cs
+++ b/src/System.Private.Interop/src/Shared/ComException.cs
@@ -21,7 +21,9 @@ namespace System.Runtime.InteropServices
 {
     // Exception for COM Interop errors where we don't recognize the HResult.
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class COMException : ExternalException
     {
         internal COMException(int hr)

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/InvalidComObjectException.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/InvalidComObjectException.cs
@@ -18,7 +18,9 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class InvalidComObjectException : SystemException
     {
         public InvalidComObjectException()

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
@@ -21,7 +21,9 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class InvalidOleVariantTypeException : SystemException
     {
         public InvalidOleVariantTypeException()

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/SEHException.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/SEHException.cs
@@ -18,7 +18,9 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class SEHException : ExternalException
     {
         public SEHException()

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
@@ -17,7 +17,9 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class SafeArrayRankMismatchException : SystemException
     {
         public SafeArrayRankMismatchException()

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
@@ -18,7 +18,9 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class SafeArrayTypeMismatchException : SystemException
     {
         public SafeArrayTypeMismatchException()


### PR DESCRIPTION
Needed for https://github.com/mono/mono/pull/9744
Also remove `using System.Diagnostics.Private;`