### PR TITLE
Ingore EETypePtr in CultureInfo on mono

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -176,7 +176,11 @@ namespace System.Globalization
                     nameof(name), name, SR.Argument_CultureNotSupported);
 
             _name = _cultureData.CultureName;
+#if MONO
+            _isInherited = (this.GetType() != typeof(System.Globalization.CultureInfo));
+#else
             _isInherited = !this.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<CultureInfo>());
+#endif
         }
 
         private CultureInfo(CultureData cultureData, bool isReadOnly = false)


### PR DESCRIPTION
I copied CoreCLR non-EETypePtr impl: https://github.com/dotnet/coreclr/blob/030a3ea9b8dbeae89c90d34441d4d9a1cf4a7de6/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs#L239