### PR TITLE
[Reflection] Bring back an "array case" handling in CustomAttributeTypedArgument ctor.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
@@ -4,7 +4,9 @@
 
 using System.Globalization;
 using System.Collections.Generic;
-
+#if MONO
+using System.Collections.ObjectModel;
+#endif
 namespace System.Reflection
 {
     public struct CustomAttributeTypedArgument
@@ -27,6 +29,16 @@ namespace System.Reflection
 
             Value = (value == null) ? null : CanonicalizeValue(value);
             ArgumentType = argumentType;
+#if MONO
+            if (value is Array) {
+                Array a = (Array)value;
+                Type etype = a.GetType().GetElementType();
+                CustomAttributeTypedArgument[] new_value = new CustomAttributeTypedArgument[a.GetLength(0)];
+                for (int i = 0; i < new_value.Length; ++i)
+                    new_value[i] = new CustomAttributeTypedArgument(etype, a.GetValue(i));
+                Value = new ReadOnlyCollection <CustomAttributeTypedArgument>(new_value);
+            }
+#endif
         }
 
         public Type ArgumentType { get; }

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
@@ -4,9 +4,7 @@
 
 using System.Globalization;
 using System.Collections.Generic;
-#if MONO
-using System.Collections.ObjectModel;
-#endif
+
 namespace System.Reflection
 {
     public struct CustomAttributeTypedArgument
@@ -30,13 +28,12 @@ namespace System.Reflection
             Value = (value == null) ? null : CanonicalizeValue(value);
             ArgumentType = argumentType;
 #if MONO
-            if (value is Array) {
-                Array a = (Array)value;
+            if (value is Array a) {
                 Type etype = a.GetType().GetElementType();
                 CustomAttributeTypedArgument[] new_value = new CustomAttributeTypedArgument[a.GetLength(0)];
                 for (int i = 0; i < new_value.Length; ++i)
                     new_value[i] = new CustomAttributeTypedArgument(etype, a.GetValue(i));
-                Value = new ReadOnlyCollection <CustomAttributeTypedArgument>(new_value);
+                Value = new System.Collections.ObjectModel.ReadOnlyCollection <CustomAttributeTypedArgument>(new_value);
             }
 #endif
         }


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/10450

Mono had it [here](https://github.com/mono/mono/blob/faaa9a41c66c31708b47bbd55d65de9f24c85aff/mcs/class/corlib/System.Reflection/CustomAttributeTypedArgument.cs#L56).
CoreRT has it [here](https://github.com/dotnet/corert/blob/635cf21aca11265ded9d78d216424bd609c052f5/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs#L189)

Mono [unit test](https://github.com/mono/mono/blob/faaa9a41c66c31708b47bbd55d65de9f24c85aff/mcs/class/corlib/Test/System.Reflection/CustomAttributeDataTest.cs#L66) for an "array case" fails without this part.