### PR TITLE
[Reflection] Handle case when "value" parameter is already of CustomAttributeTypedArgument type

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
@@ -39,6 +39,13 @@ namespace System.Reflection
 
             _lazyMemberInfo = memberInfo;
             _attributeType = memberInfo.DeclaringType;
+#if MONO
+            // Mono runtime "create_cattr_named_arg" method passes value wrapped into CustomAttributeTypedArgument object
+            // but CoreFX expects just value. 
+            if (value is CustomAttributeTypedArgument typedArument)
+                TypedValue = typedArument;    
+            else
+#endif
             TypedValue = new CustomAttributeTypedArgument(type, value);
             IsField = field != null;
             MemberName = memberInfo.Name;


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/10476.

Mono runtime "[create_cattr_named_arg](https://github.com/mono/mono/blob/7e2b62cbbb35b9fe997fcaa7aaca3aa6a1668f12/mono/metadata/custom-attrs.c#L636)" method creates CustomAttributeTypedArgument object and passes it as value parameter to CustomAttributeNamedArgument ctor. Then the value parameter just gets [casted](https://github.com/mono/mono/blob/7c19f9d443136cd76bd50bde3e13c4b43c98000f/mcs/class/corlib/System.Reflection/CustomAttributeNamedArgument.cs#L48) and assigned.

CoreRT expects just value. 

