### PR TITLE
add switch to ignore bad comparer error

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
@@ -40,7 +40,10 @@ namespace System.Collections.Generic
 
         internal static void ThrowOrIgnoreBadComparer(object comparer)
         {
-            throw new ArgumentException(SR.Format(SR.Arg_BogusIComparer, comparer));
+	    if (Environment.GetEnvironmentVariable ("MONO_IGNORE_BAD_COMPARER") == null)
+	    {
+                throw new ArgumentException(SR.Format(SR.Arg_BogusIComparer, comparer));
+	    }
         }
     }
 


### PR DESCRIPTION
This is a backwards compatibility fix that I propose. Issue identified when trying to run Terraria and throwing the ArgumentException. 

Ironically, the function is still called `ThrowOrIgnoreBadComparer`, but now it only throws.

This patch allows disabling the error on bad comparer implementation by setting the environment variable `MONO_IGNORE_BAD_COMPARER`. This fixes the error with Terraria, as well as Blueberry Garden on my testing.

The following diff adds a corresponding entry to the man page (as a gist here because it is for code in mono/mono repo): https://gist.github.com/rfht/9c65f7afc8f3ff1a44a8057809dbf1f7

Are there downsides to allowing this simple switch for legacy mono4 applications that used to get by with a bad comparer that I may not have considered?