### PR TITLE
[corlib] ThreadAbortException protection for ArraySortHelper

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
@@ -14,6 +14,7 @@
 ===========================================================*/
 
 using System.Diagnostics;
+using System.Threading;
 using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
@@ -68,6 +69,10 @@ namespace System.Collections.Generic
             {
                 IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
             }
+            catch (ThreadAbortException)
+            {
+                    throw;
+            }
             catch (Exception e)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_IComparerFailed, e);
@@ -84,6 +89,10 @@ namespace System.Collections.Generic
                 }
 
                 return InternalBinarySearch(array, index, length, value, comparer);
+            }
+            catch (ThreadAbortException)
+            {
+                    throw;
             }
             catch (Exception e)
             {
@@ -107,6 +116,10 @@ namespace System.Collections.Generic
             catch (IndexOutOfRangeException)
             {
                 IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
+            }
+            catch (ThreadAbortException)
+            {
+                    throw;
             }
             catch (Exception e)
             {
@@ -355,6 +368,10 @@ namespace System.Collections.Generic
             {
                 IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
             }
+            catch (ThreadAbortException)
+            {
+                    throw;
+            }
             catch (Exception e)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_IComparerFailed, e);
@@ -376,6 +393,10 @@ namespace System.Collections.Generic
                 {
                     return ArraySortHelper<T>.InternalBinarySearch(array, index, length, value, comparer);
                 }
+            }
+            catch (ThreadAbortException)
+            {
+                    throw;
             }
             catch (Exception e)
             {
@@ -645,6 +666,10 @@ namespace System.Collections.Generic
             {
                 IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
             }
+            catch (ThreadAbortException)
+            {
+                    throw;
+            }
             catch (Exception e)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_IComparerFailed, e);
@@ -892,6 +917,10 @@ namespace System.Collections.Generic
             catch (IndexOutOfRangeException)
             {
                 IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
+            }
+            catch (ThreadAbortException)
+            {
+                    throw;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The ArraySortHelper catches all exceptions in the comparer.
If the sorting thread is aborted while it is running the comparer, the
ArraySortHelper will catch the TAE and propagate an InvalidOperationException
instead.

As a workaround, catch and rethrow TAEs separately.

Related to https://github.com/mono/mono/issues/15418